### PR TITLE
Initialized role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,107 @@
-# osp-rbac
-Used to setup the RBAC hierarchy of an OpenStack installation.
+OpenStack Platform Role-Based Access Control
+============================================
+
+The purpose of this role is to manage RBAC setting within an OpenStack Platform installation.
+
+Requirements
+------------
+
+- Ansible 2.4+
+- Python Shade library 1.9+
+
+Role Variables
+--------------
+
+/path/to/your/group_vars/${your_group_name}:
+
+    ---
+    # osp-rbac role variable definitions
+    osp_rbac:
+      # These api-related  variables are required for OpenStack authentication.
+      api:                                            # Contains api-related variables
+        auth:                                         # Mirrors parameters of OSP modules
+          auth_url: "http://192.168.0.1:35357/v2.0"   # URL for Keystone adminURL
+          username: "admin"                           # "admin" or other global admin user
+          password: "{{ keystone_admin_password }}"   # Define on command-line via "-e" flag
+          project_name: "admin"                       # name of user's primary project
+        auth_type: "password"                         # Should be "password"
+        endpoint_type: "admin"                        # Should be "admin"
+        region_name: "RegionOne"                      # Set to adminURL's region (or omit)
+        keystone_version: "2"                         # Set to either "2" or "3"; see adminURL
+      # This dictionary should include the names of globally-defined roles.
+      # Role definitions are in policy.json/yaml files for each OSP project.
+      roles:
+        - "admin"
+        - "_member_"
+      # This dictionary defines domains, projects, and groups (as needed).
+      # Keystone v2 only supports projects, so the domains and groups are ignored.
+      # Even if you use v2, you must define a single, arbitrarily-named domain.
+      # If you use v2, you can forego the "groups" dictionary altogether.
+      domains:                                        # Dictionary containing list of domains
+      - name: default                                 # Name of one of the domains
+        projects:                                     # Dicitionary containing list of domain projects
+        - name: test1                                 # Name of one of the projects list's projects
+          description: "test1 project"                # Description of the project
+          admin:                                      # Dictionary containing admin user details
+            name: test1admin                          # Name of the project's admin user
+            password: secret                          # Initial password for user (change immediately)
+            update_password: on_create                # Password update policy; see module docs
+            email: test1admin@domain.net              # Admin user's email address
+        - name: test2                                 # Name of another project, followed by it's details
+          description: "test2 project"
+          admin:
+            name: test2admin
+            password: secret
+            update_password: on_create
+            email: test2admin@domain.net
+        groups:                                       # Dictionary containing list of domain groups
+        - name: "group1"                              # Name of one of the groups
+          description: "group1 group"                 # Description of the group
+    ...
+
+Role Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+    ---
+    - name: Validating RBAC settings of an OSP installation
+      hosts: your_host_group_here
+      become: true
+      become_user: root
+      become_method: sudo
+
+      roles:
+        - osp-rbac
+    ...
+
+Notes
+-----
+When you are creating group_vars, keep in mind that the structure is nearly identical for both Keystone v2 and v3 even though v2 will only use a subset of the variables defined in the group_vars. An example of this is the "domains" dictionary, which is required even if you are not using Keystone v3. This ensures a consist group_var structure regardless of the the API version, and allows you to seemlessly transition between v2 and v3 with very little refactoring of the group_vars. 
+
+You may have already noticed that there are no host_vars required for this role; however, there is a requirement for the `keystone_admin_password` to be set on the command line like so:
+
+```
+$ ansible-playbook -i your_inventory_filename_here -e "keystone_admin_password=your_admin_password_here" osp-rbac.yml
+```
+
+You can add an additional layer of security like so:
+
+```
+$ read -sp "Enter keystone admin password:" keystone_admin_password_variable
+Enter keystone admin password: <Enter_your_password_when_prompted>
+$ ansible-playbook -i your_inventory_filename_here -e "keystone_admin_password=${keystone_admin_password_variable}" osp-rbac.yml
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+The Development Range Engineering, Architecture, and Modernization (DREAM) Team.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for osp-rbac

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for osp-rbac

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,25 @@
+galaxy_info:
+  author: Development Range Engineering, Architecture, and Modernization (DREAM) Team
+  description: Role designed to assist in the administration of OpenStack RBAC
+  company: AFCYBER
+  license: MIT
+  min_ansible_version: 2.0
+
+  platforms:
+  - name: EL
+    versions:
+    - all
+  - name: Fedora
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
+
+  galaxy_tags: []
+
+dependencies: []
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+# tasks file for osp-rbac
+
+# Keystone v2 does not support the creation of groups and domains.
+- name: Tasks performed only when keystone_version is '2'
+  block:
+    - name: Validate OpenStack project(s) (v2 only)
+      os_project:
+        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
+        auth: "{{ osp_rbac.api.auth }}"
+        name: "{{ item.1.name }}"
+        description: "{{ item.1.description }}"
+      with_subelements:
+        - "{{ osp_rbac.domains }}"
+        - projects
+  when: osp_rbac.api.keystone_version == '2'
+
+# Keystone v3 supports the creation of domains and groups.
+# It also supports the association of projects and groups with domains.
+#
+- name: Tasks performed only when keystone_version is '3'
+  block:
+    - name: Validate OpenStack domain(s) (v3 only)
+      os_keystone_domain:
+        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
+        auth: "{{ osp_rbac.api.auth }}"
+        name: "{{ item.name }}"
+        description: "{{ item.description }}"
+      with_items:
+        - "{{ osp_rbac.domains }}"
+    - name: Validate domain project(s) (v3 only)
+      os_project:
+        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
+        auth: "{{ osp_rbac.api.auth }}"
+        name: "{{ item.1.name }}"
+        domain: "{{ item.0.name }}"
+        description: "{{ item.1.description }}"
+      with_subelements:
+        - "{{ osp_rbac.domains }}"
+        - projects
+    - name: Validate domain group(s) (v3 only)
+      os_group:
+        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
+        auth: "{{ osp_rbac.api.auth }}"
+        name: "{{ item.1.name }}"
+        description: "{{ item.1.description }}"
+        domain_id: "{{ item.0.name }}"
+      with_subelements:
+        - "{{ osp_rbac.domains }}"
+        - groups
+  when: osp_rbac.api.keystone_version == '3'
+
+- name: Validate OpenStack role(s) (v2 and v3)
+  os_keystone_role:
+    endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
+    auth: "{{ osp_rbac.api.auth }}"
+    name: "{{ item }}"
+  with_items:
+    - "{{ osp_rbac.roles }}"
+- name: Validate admin for each project (v2 and v3)
+  os_user:
+    endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
+    auth: "{{ osp_rbac.api.auth }}"
+    name: "{{ item.1.admin.name }}"
+    update_password: "{{ item.1.admin.update_password }}"
+    password: "{{ item.1.admin.password }}"
+    email: "{{ item.1.admin.email }}"
+    default_project: "{{ item.1.name }}"
+  with_subelements:
+    - "{{ osp_rbac.domains }}"
+    - projects
+- name: Validate association of project admin user(s) with admin role (v2 and v3)
+  os_user_role:
+    endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
+    auth: "{{ osp_rbac.api.auth }}"
+    user: "{{ item.1.admin.name }}"
+    project: "{{ item.1.name }}"
+    role: admin
+  with_subelements:
+    - "{{ osp_rbac.domains }}"
+    - projects
+...

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,9 @@
+---
+- hosts: test
+  become: true
+  become_method: sudo
+  become_user: root
+  gather_facts: false
+
+  roles:
+    - osp-rbac

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for osp-rbac


### PR DESCRIPTION
- Populated tasks/main.yml
- Populated README.md
- Ensured role is idempotent
- Included provisions for both keystone v2 and v3
- Included the ability to create domains (v3)
- Included the ability to create projects (v2 and v3)
- Included the ability to create groups (v3)
- Included the ability to init roles (v2 and v3)
- Included the ability to associate projects and groups with domains (v3)
- Included the ability to associate admin users with projects (v2 and v3)
- Included the ability to associate admin role with admin users (v2 and v3)