### PR TITLE
Expanded scope to include networking and FIPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,60 @@
-OpenStack Platform Role-Based Access Control
+OpenStack Platform Administrator
 ============================================
 
-The purpose of this role is to manage RBAC setting within an OpenStack Platform installation.
+The purpose of this role is to define and manage any administrator-controlled 
+OpenStack resources (i.e. domains, projects, groups, admin users, quotas, fips, et cetera)
+within an OpenStack Platform installation utilizing either Keystone v2 or v3.
 
 Requirements
 ------------
 
 - Ansible 2.4+
 - Python Shade library 1.9+
+- python-openstackclient
+- Common GNU utils (bash, wc, grep, touch)
 
 Role Variables
 --------------
 
-/path/to/your/group_vars/${your_group_name}:
+/path/to/your/playbooks/host_vars/localhost:
 
     ---
-    # osp-rbac role variable definitions
-    osp_rbac:
-      # These api-related  variables are required for OpenStack authentication.
-      api:                                            # Contains api-related variables
-        auth:                                         # Mirrors parameters of OSP modules
-          auth_url: "http://192.168.0.1:35357/v2.0"   # URL for Keystone adminURL
-          username: "admin"                           # "admin" or other global admin user
-          password: "{{ keystone_admin_password }}"   # Define on command-line via "-e" flag
-          project_name: "admin"                       # name of user's primary project
-        auth_type: "password"                         # Should be "password"
-        endpoint_type: "admin"                        # Should be "admin"
-        region_name: "RegionOne"                      # Set to adminURL's region (or omit)
-        keystone_version: "2"                         # Set to either "2" or "3"; see adminURL
+    # openstack-platform-related variable definitions
+    osp_admin:
       # This dictionary should include the names of globally-defined roles.
       # Role definitions are in policy.json/yaml files for each OSP project.
       roles:
         - "admin"
         - "_member_"
+     # The admin-defined public network that all tenants use for external access
+      global_public_network:
+        cidr: 10.16.0.0/16
+        dns_nameservers:
+          - 10.16.0.1
+      # Default quotas for each project unless they are overwritten on a per-project basis.
+      default_quotas:
+        # Quota management will be included in the next release.
       # This dictionary defines domains, projects, and groups (as needed).
       # Keystone v2 only supports projects, so the domains and groups are ignored.
-      # Even if you use v2, you must define a single, arbitrarily-named domain.
-      # If you use v2, you can forego the "groups" dictionary altogether.
+      # Even if you are using Keystone v2, the role expects a uniform dictionary structure, regardless.
+      # As a result, when using v2, you must define a single, arbitrary domain containing all projects.
+      # If you use v2, you can forego the "groups" dictionary altogether though.
       domains:                                        # Dictionary containing list of domains
       - name: default                                 # Name of one of the domains
+        description: "the default domain"             # Description of the domain
         projects:                                     # Dicitionary containing list of domain projects
+        - name: admin
+          description: "admin project"
+          admin:
+            name: admin
+            password: secret
+            update_password: on_create
+            email: admin@domain.net
+            #default_project: leave_commented         # The global admin has no "default_project"
+          private_network:
+            cidr: 192.168.0.0/24
+          public_network:
+            minimum_fips: 38
         - name: test1                                 # Name of one of the projects list's projects
           description: "test1 project"                # Description of the project
           admin:                                      # Dictionary containing admin user details
@@ -47,13 +62,23 @@ Role Variables
             password: secret                          # Initial password for user (change immediately)
             update_password: on_create                # Password update policy; see module docs
             email: test1admin@domain.net              # Admin user's email address
-        - name: test2                                 # Name of another project, followed by it's details
+            default_project: test1                    # The user's primary/default project
+          private_network:                            # Variables related to the default private/tenant net
+            cidr: 192.168.0.0/24                      # CIDR for the project's private/tenant network
+          public_network:                             # Variables related to the global-public-network
+            minimum_fips: 35                          # Minimum floating IPs project has on global-public-network
+        - name: test2
           description: "test2 project"
           admin:
             name: test2admin
             password: secret
             update_password: on_create
             email: test2admin@domain.net
+            default_project: test2
+          private_network:
+            cidr: 192.168.0.0/24
+          public_network:
+            minimum_fips: 35
         groups:                                       # Dictionary containing list of domain groups
         - name: "group1"                              # Name of one of the groups
           description: "group1 group"                 # Description of the group
@@ -68,33 +93,43 @@ Example Playbook
 ----------------
 
     ---
-    - name: Validating RBAC settings of an OSP installation
-      hosts: your_host_group_here
-      become: true
-      become_user: root
-      become_method: sudo
-
+    - hosts: localhost
+      connection: local
+      become: false
+      gather_facts: false
+    
       roles:
-        - osp-rbac
+        - osp-admin
     ...
+
 
 Notes
 -----
-When you are creating group_vars, keep in mind that the structure is nearly identical for both Keystone v2 and v3 even though v2 will only use a subset of the variables defined in the group_vars. An example of this is the "domains" dictionary, which is required even if you are not using Keystone v3. This ensures a consist group_var structure regardless of the the API version, and allows you to seemlessly transition between v2 and v3 with very little refactoring of the group_vars. 
+When you are creating host_vars, keep in mind that the structure is nearly identical for both Keystone v2 and v3 even though v2 will only use a subset of the variables defined in the host_vars. An example of this is the "domains" dictionary, which is required even if you are not using Keystone v3. This ensures a consist host_vars structure regardless of the the API version, and allows you to seemlessly transition between v2 and v3 with very little refactoring of the group_vars. 
 
-You may have already noticed that there are no host_vars required for this role; however, there is a requirement for the `keystone_admin_password` to be set on the command line like so:
+You may have already noticed that there are no group_vars required for this role; however, there is a requirement for all of the authentication credentials to be sourced in the same shell that is used to execute the playbook. Prior to running the playbook, you should be able to run `env | grep "OS_"` and see all the environment variables you'll need defined. Then, from that same terminal prompt, you will execute the playbook. Trying to execute the `source openrc` (or similar) command inside of the playbook itself does not work, because each task inside of the playbook is a child process of the shell used to execute the playbook. So, once each task completes, any env vars that it set that were specific to that child process, are dumped. These do not flow back up to the parent process that launched it.
+
+The whole reason these variables are even required, is because the `os_` series of Ansible modules requires authentication credentials in order to auth to the OpenStack installation it is managing. The modules are relatively uniform in their authentication options, and each of them offers three different ways to authenticate. The first is `cloud-client-config`. This python library reads some variables from a location on the filesystem (a cloud.yml) file. The file is setup to define multiple clouds in a single place and call them by a nickname. The modules use the `cloud` parameter to reference this nickname, and look for these files in specific directories (e.g. /etc/openstack/). This method appears to have some limitations related to how it defines and stores some of the Keystone/Identity v3 parameters though. 
+
+A similar authentication method used by these modules is the `auth` series of parameters that can be defined. These, by and large, have a one-to-one equivalency to the bash env vars defined when you `source openrc` the OpenStack provide credentials that you can download from Horizon. There are; however, some exceptions to that, which make it impractical for use. 
+
+Additionally, I have found it extremely advantageous to use the same exact authentication method that the `python-openstackclient` uses when it authenticates to Keystone to perform API calls. As a result, sourcing an OpenStack provided `openrc` file is the authentication method of choice for this role. You'll notice a test of the env vars is performed at the front end of the playbook, and you are afforded the opportunity to review the env vars before the playbook proceeds with its run. 
+
+The review time period is displayed when it reaches the appropriate step in the playbook. You can skip the review process by hitting <CTRL>+<C> and then <C> (Continue) or you can abort by hitting <CTRL>+<C> and then <A> (Abort) when prompted.
+
+
+
+Usage
+------- 
+Executing the playbook is relatively simple. Since it is executed on the localhost, there is no need for an inventory file. Ansible will throw a little warning, but its default behavior is to execute on localhost when you don't provide a user-defined group for it to run the playbook against. You'll just need to ensure you've sourced your OpenStack credentials file prior to running the playbook. Also make sure you have the `shade` library installed and accessible in your path, or else the Openstack `os_` series Ansible modules cannot execute. For FIP-related tasks, you'll also need the `python-openstackclient` installed via package manager or pip, since none of the OS modules allow for the creation of FIPs. Here is an example of the commands:
+
 
 ```
-$ ansible-playbook -i your_inventory_filename_here -e "keystone_admin_password=your_admin_password_here" osp-rbac.yml
+$ pip freeze   #ensure the "shade" module is listed in the output
+$ source ./openrc   #or whatever the name of your credentials file is...
+$ ansible-playbook osp-admin.yml
 ```
 
-You can add an additional layer of security like so:
-
-```
-$ read -sp "Enter keystone admin password:" keystone_admin_password_variable
-Enter keystone admin password: <Enter_your_password_when_prompted>
-$ ansible-playbook -i your_inventory_filename_here -e "keystone_admin_password=${keystone_admin_password_variable}" osp-rbac.yml
-```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-# defaults file for osp-rbac
+# defaults file for osp-admin

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,2 @@
 ---
-# handlers file for osp-rbac
+# handlers file for osp-admin

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Development Range Engineering, Architecture, and Modernization (DREAM) Team
-  description: Role designed to assist in the administration of OpenStack RBAC
+  description: Role designed to assist in the administration of an OpenStack installation
   company: AFCYBER
   license: MIT
   min_ansible_version: 2.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,82 +1,196 @@
 ---
-# tasks file for osp-rbac
+# tasks file for osp_admin
+
+# Checking OSP-related Bash environment variables
+- name: Ensuring authentication settings are correct
+  block:
+  - name: Getting current OSP-related Bash env vars (except ${OS_PASSWORD})
+    shell: "env | grep OS_ | egrep -v OS_PASSWORD"
+    register: osp_admin_vars
+    changed_when: false
+  - name: Printing current OSP-related Bash env vars (for debugging, if required)
+    debug:
+      var: osp_admin_vars.stdout_lines
+    changed_when: false
+  - name: Pausing so you can review these env variables to ensure you want to continue
+    pause:
+      seconds: 1
+    changed_when: false
+  - name: Ensuring authentication can occur with current OSP-related Bash env vars
+    os_auth:
+      auth_type: password
+    changed_when: false
+  - name: Determining tasks to run based on value of ${OS_IDENTITY_API_VERSION} Bash env var
+    set_fact:
+      keystone_api_version: "{{ lookup('env', 'OS_IDENTITY_API_VERSION') }}"
+    changed_when: false
 
 # Keystone v2 does not support the creation of groups and domains.
 - name: Tasks performed only when keystone_version is '2'
   block:
     - name: Validate OpenStack project(s) (v2 only)
       os_project:
-        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
-        auth: "{{ osp_rbac.api.auth }}"
+        endpoint_type: admin
         name: "{{ item.1.name }}"
         description: "{{ item.1.description }}"
       with_subelements:
-        - "{{ osp_rbac.domains }}"
+        - "{{ osp_admin.domains }}"
         - projects
-  when: osp_rbac.api.keystone_version == '2'
+    - name: Validating admin for each project (v2 only)
+      os_user:
+        endpoint_type: admin
+        name: "{{ item.1.admin.name }}"
+        update_password: "{{ item.1.admin.update_password }}"
+        password: "{{ item.1.admin.password }}"
+        email: "{{ item.1.admin.email }}"
+        default_project: "{{ item.1.admin.default_project|default(omit) }}"
+      with_subelements:
+        - "{{ osp_admin.domains }}"
+        - projects
+  when: keystone_api_version == '2'
 
 # Keystone v3 supports the creation of domains and groups.
 # It also supports the association of projects and groups with domains.
-#
 - name: Tasks performed only when keystone_version is '3'
   block:
-    - name: Validate OpenStack domain(s) (v3 only)
+    - name: Validating OpenStack domain(s) (v3 only)
       os_keystone_domain:
-        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
-        auth: "{{ osp_rbac.api.auth }}"
+        endpoint_type: admin
         name: "{{ item.name }}"
         description: "{{ item.description }}"
       with_items:
-        - "{{ osp_rbac.domains }}"
-    - name: Validate domain project(s) (v3 only)
+        - "{{ osp_admin.domains }}"
+    - name: Validating domain project(s) (v3 only)
       os_project:
-        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
-        auth: "{{ osp_rbac.api.auth }}"
+        endpoint_type: admin
         name: "{{ item.1.name }}"
         domain: "{{ item.0.name }}"
         description: "{{ item.1.description }}"
       with_subelements:
-        - "{{ osp_rbac.domains }}"
+        - "{{ osp_admin.domains }}"
         - projects
-    - name: Validate domain group(s) (v3 only)
+    - name: Validating domain group(s) (v3 only)
       os_group:
-        endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
-        auth: "{{ osp_rbac.api.auth }}"
+        endpoint_type: admin
         name: "{{ item.1.name }}"
         description: "{{ item.1.description }}"
         domain_id: "{{ item.0.name }}"
       with_subelements:
-        - "{{ osp_rbac.domains }}"
+        - "{{ osp_admin.domains }}"
         - groups
-  when: osp_rbac.api.keystone_version == '3'
+    - name: Validating domain-admins group for each domain (v3 only)
+      os_group:
+        endpoint_type: admin
+        name: "{{ item.name }}-domain-admins"
+        description: "Admins for {{ item.name }} domain"
+        domain_id: "{{ item.name }}"
+      with_items:
+        - "{{ osp_admin.domains }}"
+    - name: Validating admin user for each project (v3 only)
+      os_user:
+        endpoint_type: admin
+        name: "{{ item.1.admin.name }}"
+        update_password: "{{ item.1.admin.update_password }}"
+        password: "{{ item.1.admin.password }}"
+        email: "{{ item.1.admin.email }}"
+        default_project: "{{ item.1.admin.default_project|default(omit) }}"
+        domain: "{{ item.0.name }}"
+      with_subelements:
+        - "{{ osp_admin.domains }}"
+        - projects
+  when: keystone_api_version == '3'
 
-- name: Validate OpenStack role(s) (v2 and v3)
+# Tasks common to both Identity API v2 and v3
+- name: Validating OpenStack role(s) (v2 and v3)
   os_keystone_role:
-    endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
-    auth: "{{ osp_rbac.api.auth }}"
+    endpoint_type: admin
     name: "{{ item }}"
   with_items:
-    - "{{ osp_rbac.roles }}"
-- name: Validate admin for each project (v2 and v3)
-  os_user:
-    endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
-    auth: "{{ osp_rbac.api.auth }}"
-    name: "{{ item.1.admin.name }}"
-    update_password: "{{ item.1.admin.update_password }}"
-    password: "{{ item.1.admin.password }}"
-    email: "{{ item.1.admin.email }}"
-    default_project: "{{ item.1.name }}"
-  with_subelements:
-    - "{{ osp_rbac.domains }}"
-    - projects
-- name: Validate association of project admin user(s) with admin role (v2 and v3)
+    - "{{ osp_admin.roles }}"
+- name: Validating association of project admin user(s) with admin role (v2 and v3)
   os_user_role:
-    endpoint_type: "{{ osp_rbac.api.endpoint_type }}"
-    auth: "{{ osp_rbac.api.auth }}"
+    endpoint_type: admin
     user: "{{ item.1.admin.name }}"
     project: "{{ item.1.name }}"
     role: admin
   with_subelements:
-    - "{{ osp_rbac.domains }}"
+    - "{{ osp_admin.domains }}"
+    - projects
+- name: Validating that openstack-admin group is a project member for all projects (v2 and v3)
+  os_user_role:
+    endpoint_type: admin
+    user: "{{ item.1.admin.name }}"
+    project: "{{ item.1.name }}"
+    role: admin
+  with_subelements:
+    - "{{ osp_admin.domains }}"
+    - projects
+- name: Validating global-public-network (v2 and v3)
+  os_network:
+    endpoint_type: public
+    project: admin
+    external: true
+    shared: true
+    name: "global-public-network"
+- name: Validating global-public-subnet (v2 and v3)
+  os_subnet:
+    endpoint_type: public
+    project: admin
+    name: "global-public-subnet"
+    network_name: "global-public-network"
+    cidr: "{{ osp_admin.global_public_network.cidr }}"
+- name: Ensuring existence of each projects' primary, private network (v2 and v3)
+  os_network:
+    endpoint_type: public
+    project: "{{ item.1.name }}"
+    name: "{{ item.1.name }}-private-network"
+  with_subelements:
+    - "{{ osp_admin.domains }}"
+    - projects
+- name: Ensuring existence of each projects' primary, private network's subnet (v2 and v3)
+  os_subnet:
+    endpoint_type: public
+    project: "{{ item.1.name }}"
+    name: "{{ item.1.name }}-private-subnet"
+    network_name: "{{ item.1.name }}-private-network"
+    cidr: "{{ item.1.private_network.cidr }}"
+    enable_dhcp: true
+  with_subelements:
+    - "{{ osp_admin.domains }}"
+    - projects
+- name: Validating global-public-router settings (v2 and v3)
+  os_router:
+    endpoint_type: public
+    project: admin
+    name: "global-public-router"
+    network: global-public-network
+- name: Validating each projects' primary, private subnet's router's settings (v2 and v3)
+  os_router:
+    endpoint_type: public
+    project: "{{ item.1.name }}"
+    name: "{{ item.1.name }}-private-router"
+    network: global-public-network
+    external_fixed_ips:
+      - subnet: global-public-subnet
+    interfaces:
+      - "{{ item.1.name }}-private-subnet"
+  with_subelements:
+    - "{{ osp_admin.domains }}"
+    - projects
+- name: Ensuring each project has its designated minimum amount of floating IPs
+  shell: "openstack floating ip list -f value --project {{ item.1.name }} | wc -l | while read count; do until [ $count -ge {{ item.1.public_network.minimum_fips }} ]; do openstack floating ip create --project {{ item.1.name }} global-public-network; let count+=1; touch '.osp_admin.ansible_changed_{{ item.1.name }}'; done; done"
+  args:
+    executable: /bin/bash
+    chdir: "{{ lookup('env', 'HOME') }}"
+  with_subelements:
+    - "{{ osp_admin.domains }}"
+    - projects
+  changed_when: false
+- name: Checking to see if new Floating IP (FIP) creation was attempted for each project
+  file:
+    path: "$HOME/.osp_admin.ansible_changed_{{ item.1.name }}"
+    state: absent
+  with_subelements:
+    - "{{ osp_admin.domains }}"
     - projects
 ...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,9 +1,6 @@
 ---
-- hosts: test
-  become: true
-  become_method: sudo
-  become_user: root
+- hosts: localhost
   gather_facts: false
 
   roles:
-    - osp-rbac
+    - osp-admin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-# vars file for osp-rbac
+# vars file for osp-admin


### PR DESCRIPTION
- Added features to create global-public-network/subnet/router and FIP pool
- Added features to create each tenant private-network/subnet/router
- Added features to create a minimum number of Floating IPs (FIPs) for each project
- Updated README
- Updated several files that reference osp-rbac, replaced with osp-admin in prep for repo rename
- Tested on devstack-latest (Queens) against v3 of Keystone API; confirmed to be  idempotent and fully functional